### PR TITLE
added option to specify childrenDepend fields in options

### DIFF
--- a/lib/publication.js
+++ b/lib/publication.js
@@ -3,6 +3,7 @@ Publication = function Publication(subscription, options, args) {
     this.options = options;
     this.args = args || [];
     this.childrenOptions = options.children || [];
+    this.childrenDepend = options.childrenDepend || [];
     this.publishedDocs = new PublishedDocumentList();
     this.collectionName = options.collectionName;
 };
@@ -23,16 +24,21 @@ Publication.prototype.publish = function publish() {
                 debugLog('Publication.observeHandle.added', collectionName + ':' + doc._id + ' already published');
                 self.publishedDocs.unflagForRemoval(doc._id);
                 self.subscription.changed(collectionName, doc._id, doc);
-                self._republishChildrenOf(doc);
+                if (self.hasChildrenDepend(_.keys(doc))) {
+                    self._republishChildrenOf(doc);
+                }
             } else {
                 self.publishedDocs.add(collectionName, doc._id);
                 self.subscription.added(collectionName, doc);
                 self._publishChildrenOf(doc);
             }
         },
-        changed: function changed(newDoc) {
+        changed: function changed(newDoc, oldDoc) {
             debugLog('Publication.observeHandle.changed', collectionName + ':' + newDoc._id);
-            self._republishChildrenOf(newDoc);
+            var changes = DiffSequence.makeChangedFields(newDoc, oldDoc);
+            if (self.hasChildrenDepend(_.keys(changes))) {
+                self._republishChildrenOf(newDoc);
+            }
         },
         removed: function removed(doc) {
             debugLog('Publication.observeHandle.removed', collectionName + ':' + doc._id);
@@ -46,6 +52,15 @@ Publication.prototype.publish = function publish() {
             self.subscription.changed(collectionName, id, fields);
         }
     });
+};
+
+Publication.prototype.hasChildrenDepend = function hasChildrenDepend(keysArr) {
+    debugLog('Publication.hasChildrenDepend', this._getCollectionName());
+    if (!this.childrenDepend.length) {
+        return true;
+    }
+    var releventChangedFields = _.intersection(keysArr, this.childrenDepend);
+    return !!(releventChangedFields && releventChangedFields.length);
 };
 
 Publication.prototype.unpublish = function unpublish() {

--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-    name: "reywood:publish-composite",
+    name: "okland:publish-composite",
     summary: "Publish a set of related documents from multiple collections with a reactive join",
     version: "1.4.2",
     git: "https://github.com/englue/meteor-publish-composite.git"
@@ -7,7 +7,7 @@ Package.describe({
 
 Package.on_use(function (api) {
     api.versionsFrom("METEOR@0.9.0");
-    api.use("underscore", "server");
+    api.use(["underscore", "diff-sequence"], "server");
     api.add_files([
         "lib/doc_ref_counter.js",
         "lib/publication.js",
@@ -18,7 +18,8 @@ Package.on_use(function (api) {
 
 
 Package.on_test(function(api) {
-    api.use("reywood:publish-composite");
+    api.use("okland:publish-composite");
+    api.imply(["mongo", "ddp-client", "ddp-server","underscore"]);
     api.use(["tinytest", "test-helpers"]);
 
     api.add_files([ "tests.js" ]);


### PR DESCRIPTION
Added option to specify on which fields the children depend so it will not re-publish children of object when not relevant fields changes.
