### PR TITLE
Don't add client-side dependencies

### DIFF
--- a/package.js
+++ b/package.js
@@ -12,7 +12,7 @@ Package.onUse((api) => {
         'ecmascript',
         'modules',
         'underscore',
-    ], ['client', 'server']);
+    ], ['server']);
     api.mainModule('lib/publish_composite.js', 'server');
     api.addFiles([
         'lib/doc_ref_counter.js',


### PR DESCRIPTION
The package definition was including unnecessary packages in the client-side bundle.