### PR TITLE
Allow to pass async function to publishComposite

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,31 @@ var userId = 1, limit = 10;
 Meteor.subscribe('postsByUser', userId, limit);
 ```
 
+### Example 3: A publication from async function
+
+Note a function is passed for the `options` argument to `publishComposite`.
+
+```javascript
+// Server
+import { publishComposite } from 'meteor/reywood:publish-composite';
+
+publishComposite('postsByUser', async function(userId) {
+    const user = await Users.findOneAsync(userId)
+    const limit = user.limit
+
+    return {
+        find() {
+            // Find posts made by user. Note arguments for callback function
+            // being used in query.
+            return Posts.find({ authorId: userId }, { limit: limit });
+        },
+        children: [
+            // This section will be similar to that of the previous example.
+        ]
+    }
+});
+```
+
 ## Known issues
 
 **Avoid publishing very large sets of documents**

--- a/lib/publish_composite.js
+++ b/lib/publish_composite.js
@@ -5,9 +5,9 @@ import Subscription from './subscription'
 import { debugLog, enableDebugLogging } from './logging'
 
 function publishComposite (name, options) {
-  return Meteor.publish(name, function publish (...args) {
+  return Meteor.publish(name, async function publish (...args) {
     const subscription = new Subscription(this)
-    const instanceOptions = prepareOptions.call(this, options, args)
+    const instanceOptions = await prepareOptions.call(this, options, args)
     const publications = []
 
     instanceOptions.forEach((opt) => {
@@ -28,11 +28,11 @@ function publishComposite (name, options) {
 // For backwards compatibility
 Meteor.publishComposite = publishComposite
 
-function prepareOptions (options, args) {
+async function prepareOptions (options, args) {
   let preparedOptions = options
 
   if (typeof preparedOptions === 'function') {
-    preparedOptions = preparedOptions.apply(this, args)
+    preparedOptions = await preparedOptions.apply(this, args)
   }
 
   if (!preparedOptions) {

--- a/tests/client.js
+++ b/tests/client.js
@@ -62,6 +62,17 @@ describe('publishComposite', () => {
     }
   })
 
+  testPublication('Should publish all posts via async callback', {
+    publication: 'allPostsAsync',
+
+    testHandler: (onComplete) => {
+      const posts = Posts.find()
+      asyncExpect(() => expect(posts.count()).to.equal(4), onComplete)
+
+      onComplete()
+    }
+  })
+
   testPublication('Should publish all post authors', {
     publication: 'allPosts',
 

--- a/tests/server.js
+++ b/tests/server.js
@@ -38,6 +38,15 @@ publishComposite('allPosts', {
   children: postPublicationChildren
 })
 
+publishComposite('allPostsAsync', async ()=> {
+  return {
+    find () {
+      return Posts.find()
+    },
+    children: postPublicationChildren
+  }
+})
+
 publishComposite('allPostsWithChildrenAsFunction', {
   find () {
     return Posts.find()


### PR DESCRIPTION
<!--
Thank you for your interest in the project! We appreciate your submission!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

Read a guide on [opening pull requests](https://opensource.guide/how-to-contribute/#opening-a-pull-request).

-->

<!-- What changes are being made? (What feature/bug is being fixed here?)
Check this [list](https://help.github.com/en/articles/closing-issues-using-keywords) of valid keywords.
-->
## What

This PR allows to pass an async function to publishComposite

<!-- Why are these changes necessary? -->
## Why

With Meteor async migration, there may be cases where awaiting for results is needed inside the callback.

<!-- Anything else beside this PR that needs to happen? -->
