### PR TITLE
find and children async

### DIFF
--- a/lib/publication.js
+++ b/lib/publication.js
@@ -5,7 +5,7 @@ import { debugLog } from './logging'
 import PublishedDocumentList from './published_document_list'
 
 class Publication {
-  constructor (subscription, options, args) {
+  constructor(subscription, options, args) {
     check(options, {
       find: Function,
       children: Match.Optional(Match.OneOf([Object], Function)),
@@ -20,8 +20,8 @@ class Publication {
     this.collectionName = options.collectionName
   }
 
-  publish () {
-    this.cursor = this._getCursor()
+  async publish() {
+    this.cursor = await this._getCursor()
     if (!this.cursor) { return }
 
     const collectionName = this._getCollectionName()
@@ -30,7 +30,7 @@ class Publication {
     // environmentVariables as when publishing the "parent".
     // It's only needed when publish is being recursively run.
     this.observeHandle = this.cursor.observe({
-      added: Meteor.bindEnvironment((doc) => {
+      added: Meteor.bindEnvironment(async (doc) => {
         const alreadyPublished = this.publishedDocs.has(doc._id)
 
         if (alreadyPublished) {
@@ -40,7 +40,7 @@ class Publication {
           this.subscription.changed(collectionName, doc._id, doc)
         } else {
           this.publishedDocs.add(collectionName, doc._id)
-          this._publishChildrenOf(doc)
+          await this._publishChildrenOf(doc)
           this.subscription.added(collectionName, doc)
         }
       }),
@@ -59,46 +59,46 @@ class Publication {
     })
   }
 
-  unpublish () {
+  unpublish() {
     debugLog('Publication.unpublish', this._getCollectionName())
     this._stopObservingCursor()
     this._unpublishAllDocuments()
   }
 
-  _republish () {
+  async _republish() {
     this._stopObservingCursor()
 
     this.publishedDocs.flagAllForRemoval()
 
     debugLog('Publication._republish', 'run .publish again')
-    this.publish()
+    await this.publish()
 
     debugLog('Publication._republish', 'unpublish docs from old cursor')
     this._removeFlaggedDocs()
   }
 
-  _getCursor () {
-    return this.options.find.apply(this.subscription.meteorSub, this.args)
+  async _getCursor() {
+    return await this.options.find.apply(this.subscription.meteorSub, this.args)
   }
 
-  _getCollectionName () {
+  _getCollectionName() {
     return this.collectionName || (this.cursor && this.cursor._getCollectionName())
   }
 
-  _publishChildrenOf (doc) {
+  async _publishChildrenOf(doc) {
     const children = typeof this.childrenOptions === 'function'
       ? this.childrenOptions(doc, ...this.args) : this.childrenOptions
-    children.forEach((options) => {
+    for (const options of children) {
       const pub = new Publication(this.subscription, options, [doc].concat(this.args))
       this.publishedDocs.addChildPub(doc._id, pub)
-      pub.publish()
-    })
+      await pub.publish()
+    }
   }
 
-  _republishChildrenOf (doc) {
+  _republishChildrenOf(doc) {
     const parentArgs = this.args
     let newArgs
-    this.publishedDocs.eachChildPub(doc._id, (publication) => {
+    this.publishedDocs.eachChildPub(doc._id, async (publication) => {
       // Check if parent's args are the same length as this publication
       // Intuitively this should not ever be the case! However it does happen sometimes.
       // When it does the first argument of the parent publication is the doc.
@@ -114,17 +114,17 @@ class Publication {
       // These may have been updated by a grandparent publication.
       publication.args = [doc, ...newArgs]
 
-      publication._republish()
+      await publication._republish()
     })
   }
 
-  _unpublishAllDocuments () {
+  _unpublishAllDocuments() {
     this.publishedDocs.eachDocument((doc) => {
       this._removeDoc(doc.collectionName, doc.docId)
     }, this)
   }
 
-  _stopObservingCursor () {
+  _stopObservingCursor() {
     debugLog('Publication._stopObservingCursor', 'stop observing cursor')
 
     if (this.observeHandle) {
@@ -133,7 +133,7 @@ class Publication {
     }
   }
 
-  _removeFlaggedDocs () {
+  _removeFlaggedDocs() {
     this.publishedDocs.eachDocument((doc) => {
       if (doc.isFlaggedForRemoval()) {
         this._removeDoc(doc.collectionName, doc.docId)
@@ -141,13 +141,13 @@ class Publication {
     }, this)
   }
 
-  _removeDoc (collectionName, docId) {
+  _removeDoc(collectionName, docId) {
     this.subscription.removed(collectionName, docId)
     this._unpublishChildrenOf(docId)
     this.publishedDocs.remove(docId)
   }
 
-  _unpublishChildrenOf (docId) {
+  _unpublishChildrenOf(docId) {
     debugLog('Publication._unpublishChildrenOf', `unpublishing children of ${this._getCollectionName()}:${docId}`)
 
     this.publishedDocs.eachChildPub(docId, (publication) => {

--- a/lib/publish_composite.js
+++ b/lib/publish_composite.js
@@ -4,17 +4,17 @@ import Publication from './publication'
 import Subscription from './subscription'
 import { debugLog, enableDebugLogging } from './logging'
 
-function publishComposite (name, options) {
-  return Meteor.publish(name, async function publish (...args) {
+function publishComposite(name, options) {
+  return Meteor.publish(name, async function publish(...args) {
     const subscription = new Subscription(this)
     const instanceOptions = await prepareOptions.call(this, options, args)
     const publications = []
 
-    instanceOptions.forEach((opt) => {
+    for (const opt of instanceOptions) {
       const pub = new Publication(subscription, opt)
-      pub.publish()
+      await pub.publish()
       publications.push(pub)
-    })
+    }
 
     this.onStop(() => {
       publications.forEach(pub => pub.unpublish())
@@ -28,7 +28,7 @@ function publishComposite (name, options) {
 // For backwards compatibility
 Meteor.publishComposite = publishComposite
 
-async function prepareOptions (options, args) {
+async function prepareOptions(options, args) {
   let preparedOptions = options
 
   if (typeof preparedOptions === 'function') {


### PR DESCRIPTION
<!--
Thank you for your interest in the project! We appreciate your submission!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

Read a guide on [opening pull requests](https://opensource.guide/how-to-contribute/#opening-a-pull-request).

-->

<!-- What changes are being made? (What feature/bug is being fixed here?)
Check this [list](https://help.github.com/en/articles/closing-issues-using-keywords) of valid keywords.
-->
## What

Add the possibility that "find" and "children" are async

## Why

With Meteor async migration, there may be cases where awaiting for results is needed inside the callback.
