### PR TITLE
Replaces underscore references with native one

### DIFF
--- a/lib/published_document_list.js
+++ b/lib/published_document_list.js
@@ -43,9 +43,9 @@ class PublishedDocumentList {
   }
 
   eachDocument (callback, context) {
-    _.each(this.documents, function execCallbackOnDoc (doc) {
+    Object.entries(this.documents).forEach(function execCallbackOnDoc (doc) {
       callback.call(this, doc)
-    }, context || this)
+    }, context || this) 
   }
 
   eachChildPub (docId, callback) {

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -48,7 +48,7 @@ class Subscription {
   _updateDocHash (collectionName, id, changes) {
     const key = buildHashKey(collectionName, id)
     const existingDoc = this.docHash[key] || {}
-    this.docHash[key] = _.extend(existingDoc, changes)
+    this.docHash[key] = Object.assign(existingDoc, changes)
   }
 
   _shouldSendChanges (collectionName, id, changes) {
@@ -66,7 +66,8 @@ class Subscription {
 
     if (!existingDoc) { return true }
 
-    return _.any(_.keys(doc), key => !_.isEqual(doc[key], existingDoc[key]))
+    return _.any(Object.keys(doc),
+                key => !_.isEqual(doc[key], existingDoc[key]))
   }
 
   _removeDocHash (collectionName, id) {

--- a/tests/server.js
+++ b/tests/server.js
@@ -242,8 +242,7 @@ function insertPost (title, author, comments) {
   if (comments) {
     for (let i = 0; i < comments.length; i++) {
       commentId = new Mongo.ObjectID()
-      commentData = _.extend({ _id: commentId, postId }, comments[i])
-
+      commentData = Object.assign({ _id: commentId, postId }, comments[i])
       Comments.insert(commentData)
     }
   }


### PR DESCRIPTION

Resolves #158 

Underscore references in certain files where possible are replaced with native ones as referenced in https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore. Currently, the native version isn't available for _.any() and _.isEqual() in lines 69 and 70 in lib/subscription.js, so these are skipped for now. The following changes are made-

1. _.each(list, function) to Object.entries(object).forEach(function) 
    https://github.com/Nandika-A/meteor-publish-composite/commit/da63cfa39553d673530226e27056c5d4fce12a59
2. _.extend(destination, *sources) to Object.assign(destination, *sources)   
    https://github.com/Nandika-A/meteor-publish-composite/commit/6d5f2a0c63968a13a7e5c29c820169f68a7a7b76
    https://github.com/Nandika-A/meteor-publish-composite/commit/da3aff7c6490db37d72a57d33fa7cc20c18f67da
4. _.keys(object) to Object.keys(object)
    https://github.com/Nandika-A/meteor-publish-composite/commit/6d5f2a0c63968a13a7e5c29c820169f68a7a7b76

The changes are made in a separate branch Replaces underscore references with native one.
The remaining underscore functions will be tackled in other pr.