### PR TITLE
Replace underscore/lodash references in _.any() and _.isequal() with natives

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ end_of_line = lf
 insert_final_newline = true
 
 [*.{js,json,md}]
-indent_size = 4
+indent_size = 2
 trim_trailing_whitespace = true
 
 [versions.json]

--- a/.npm/package/.gitignore
+++ b/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.npm/package/README
+++ b/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/.npm/package/npm-shrinkwrap.json
+++ b/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,10 @@
+{
+  "lockfileVersion": 1,
+  "dependencies": {
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    }
+  }
+}

--- a/lib/published_document_list.js
+++ b/lib/published_document_list.js
@@ -1,5 +1,3 @@
-import { _ } from 'meteor/underscore'
-
 import PublishedDocument from './published_document'
 
 class PublishedDocumentList {
@@ -45,7 +43,7 @@ class PublishedDocumentList {
   eachDocument (callback, context) {
     Object.entries(this.documents).forEach(function execCallbackOnDoc (doc) {
       callback.call(this, doc)
-    }, context || this) 
+    }, context || this)
   }
 
   eachChildPub (docId, callback) {

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -65,8 +65,7 @@ class Subscription {
 
     if (!existingDoc) { return true }
 
-    return Object.keys(doc).some(key => !isEqual(doc[key],
-                                 existingDoc[key]))
+    return Object.keys(doc).some(key => !isEqual(doc[key], existingDoc[key]))
   }
 
   _removeDocHash (collectionName, id) {

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -3,7 +3,7 @@ import { _ } from 'meteor/underscore'
 import DocumentRefCounter from './doc_ref_counter'
 import { debugLog } from './logging'
 
-var isEqual = require('lodash.isequal');
+import { isEqual } from 'node_modules/lodash.isequal'
 
 class Subscription {
   constructor (meteorSub) {

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -3,6 +3,8 @@ import { _ } from 'meteor/underscore'
 import DocumentRefCounter from './doc_ref_counter'
 import { debugLog } from './logging'
 
+var isEqual = require('lodash.isequal');
+
 class Subscription {
   constructor (meteorSub) {
     this.meteorSub = meteorSub
@@ -66,8 +68,8 @@ class Subscription {
 
     if (!existingDoc) { return true }
 
-    return _.any(Object.keys(doc),
-                key => !_.isEqual(doc[key], existingDoc[key]))
+    return Object.keys(doc).some(key => !isEqual(doc[key],
+                                 existingDoc[key]))
   }
 
   _removeDocHash (collectionName, id) {

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -2,6 +2,8 @@ import DocumentRefCounter from './doc_ref_counter'
 import { debugLog } from './logging'
 import { isEqual } from 'lodash.isequal'
 
+const isEqual = Npm.require('lodash.isequal')
+
 class Subscription {
   constructor (meteorSub) {
     this.meteorSub = meteorSub

--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -1,9 +1,6 @@
-import { _ } from 'meteor/underscore'
-
 import DocumentRefCounter from './doc_ref_counter'
 import { debugLog } from './logging'
-
-import { isEqual } from 'node_modules/lodash.isequal'
+import { isEqual } from 'lodash.isequal'
 
 class Subscription {
   constructor (meteorSub) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2020,7 +2020,8 @@
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2017,6 +2017,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",

--- a/package.js
+++ b/package.js
@@ -7,7 +7,7 @@ Package.describe({
 })
 
 Npm.depends({
-    "lodash.isequal": "^4.5.0"
+  "lodash.isequal": "4.5.0"
 })
 
 Package.onUse((api) => {
@@ -16,7 +16,7 @@ Package.onUse((api) => {
     'check',
     'ecmascript',
     'modules',
-    'underscore'
+    'logging'
   ], ['server'])
   api.mainModule('lib/publish_composite.js', 'server')
   api.addFiles([

--- a/package.js
+++ b/package.js
@@ -6,6 +6,10 @@ Package.describe({
   git: 'https://github.com/Meteor-Community-Packages/meteor-publish-composite'
 })
 
+Npm.depends({
+    "lodash.isequal": "^4.5.0"
+})
+
 Package.onUse((api) => {
   api.versionsFrom(['1.8.3', '2.8.1', '3.0-alpha.15'])
   api.use([

--- a/package.json
+++ b/package.json
@@ -31,9 +31,7 @@
     "all-contributors-cli": "^6.26.1",
     "babel-eslint": "^10.1.0",
     "husky": "^8.0.3",
+    "lodash.isequal": "^4.5.0",
     "standard": "^17.1.0"
-  },
-  "dependencies": {
-    "lodash.isequal": "^4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "homepage": "https://github.com/Meteor-Community-Packages/meteor-publish-composite#readme",
   "scripts": {
-    "test": "npm run lint && meteor test-packages ./ --driver-package cultofcoders:mocha",
+    "test": "npm run lint && npm run test:package",
+    "test:package": "meteor test-packages ./ --driver-package cultofcoders:mocha",
     "lint": "./node_modules/.bin/standard --fix",
     "publish": "npm prune --production && meteor publish && meteor npm i",
     "all-contributors": "./node_modules/.bin/all-contributors",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "babel-eslint": "^10.1.0",
     "husky": "^8.0.3",
     "standard": "^17.1.0"
+  },
+  "dependencies": {
+    "lodash.isequal": "^4.5.0"
   }
 }

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,6 +1,5 @@
 import { Meteor } from 'meteor/meteor'
 import { Mongo } from 'meteor/mongo'
-import { _ } from 'meteor/underscore'
 import { enableDebugLogging, publishComposite } from 'meteor/reywood:publish-composite'
 
 import { Authors, Comments, Posts } from './common'


### PR DESCRIPTION
Resolves #158 

Underscore and lodash references in lib/subscription.js in _.any() and _.isEqual() are replaced.
1. _.any(): replaced with [Array.some()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some)
2. _.isEqual(): This method is imported as a Node module using `npm i --save lodash.isequal` as mentioned in the documentation. [link](https://www.npmjs.com/package/lodash.isequal?activeTab=code).  This module is imported in subscription.js as a package `var isEqual = require('lodash.isequal');`.
