### PR TITLE
fix _publishChildrenOf use Promise.all

### DIFF
--- a/lib/publication.js
+++ b/lib/publication.js
@@ -90,10 +90,10 @@ class Publication {
       ? this.childrenOptions(doc, ...this.args)
       : this.childrenOptions
     await Promise.all(children.map(async (options) => {
-       const pub = new Publication(this.subscription, options, [doc].concat(this.args))
-       this.publishedDocs.addChildPub(doc._id, pub)
-       await pub.publish()
-    }));
+      const pub = new Publication(this.subscription, options, [doc].concat(this.args))
+      this.publishedDocs.addChildPub(doc._id, pub)
+      await pub.publish()
+    }))
   }
 
   _republishChildrenOf (doc) {

--- a/lib/publication.js
+++ b/lib/publication.js
@@ -89,11 +89,11 @@ class Publication {
     const children = typeof this.childrenOptions === 'function'
       ? this.childrenOptions(doc, ...this.args)
       : this.childrenOptions
-    for (const options of children) {
-      const pub = new Publication(this.subscription, options, [doc].concat(this.args))
-      this.publishedDocs.addChildPub(doc._id, pub)
-      await pub.publish()
-    }
+    await Promise.all(children.map(async (options) => {
+       const pub = new Publication(this.subscription, options, [doc].concat(this.args))
+       this.publishedDocs.addChildPub(doc._id, pub)
+       await pub.publish()
+    }));
   }
 
   _republishChildrenOf (doc) {


### PR DESCRIPTION
<!--
Thank you for your interest in the project! We appreciate your submission!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

Read a guide on [opening pull requests](https://opensource.guide/how-to-contribute/#opening-a-pull-request).

-->

<!-- What changes are being made? (What feature/bug is being fixed here?)
Check this [list](https://help.github.com/en/articles/closing-issues-using-keywords) of valid keywords.
-->
## What

possible fix #167 

## Why

replace "for of" with "Promise.all" to keep the parallelism in _publishChildrenOf
