### PR TITLE
Fixes this.ready() being fired too early

### DIFF
--- a/.versions
+++ b/.versions
@@ -32,7 +32,7 @@ htmljs@1.0.11
 id-map@1.1.1
 inter-process-messaging@0.1.1
 jquery@1.11.11
-local-test:reywood:publish-composite@1.8.5-beta.1
+local-test:reywood:publish-composite@1.8.5-beta.2
 logging@1.3.2
 meteor@1.11.3
 minimongo@1.9.3
@@ -56,7 +56,7 @@ react-fast-refresh@0.2.7
 reactive-var@1.0.12
 reload@1.3.1
 retry@1.1.0
-reywood:publish-composite@1.8.5-beta.1
+reywood:publish-composite@1.8.5-beta.2
 routepolicy@1.1.1
 socket-stream-client@0.5.1
 spacebars@1.0.13

--- a/.versions
+++ b/.versions
@@ -32,7 +32,7 @@ htmljs@1.0.11
 id-map@1.1.1
 inter-process-messaging@0.1.1
 jquery@1.11.11
-local-test:reywood:publish-composite@1.8.4
+local-test:reywood:publish-composite@1.8.5-beta.1
 logging@1.3.2
 meteor@1.11.3
 minimongo@1.9.3
@@ -56,7 +56,7 @@ react-fast-refresh@0.2.7
 reactive-var@1.0.12
 reload@1.3.1
 retry@1.1.0
-reywood:publish-composite@1.8.4
+reywood:publish-composite@1.8.5-beta.1
 routepolicy@1.1.1
 socket-stream-client@0.5.1
 spacebars@1.0.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v1.8.5
+* Fixed `this.ready()` being fired too early [PR](https://github.com/Meteor-Community-Packages/meteor-publish-composite/pull/174) [manueltimita](https://github.com/manueltimita)
+
 ## v1.8.4
 
 * Added basic TypeScript types [PR](https://github.com/Meteor-Community-Packages/meteor-publish-composite/pull/166) [@storytellercz](https://github.com/sponsors/StorytellerCZ)

--- a/lib/publication.js
+++ b/lib/publication.js
@@ -18,6 +18,8 @@ class Publication {
     this.childrenOptions = options.children || []
     this.publishedDocs = new PublishedDocumentList()
     this.collectionName = options.collectionName
+    // property to store promises for added callbacks
+    this.addedPromises = [];
   }
 
   async publish () {
@@ -31,18 +33,26 @@ class Publication {
     // It's only needed when publish is being recursively run.
     this.observeHandle = this.cursor.observe({
       added: Meteor.bindEnvironment(async (doc) => {
-        const alreadyPublished = this.publishedDocs.has(doc._id)
+        const addedPromise = new Promise(async (resolve) => {
+          const alreadyPublished = this.publishedDocs.has(doc._id)
 
-        if (alreadyPublished) {
-          debugLog('Publication.observeHandle.added', `${collectionName}:${doc._id} already published`)
-          this.publishedDocs.unflagForRemoval(doc._id)
-          this._republishChildrenOf(doc)
-          this.subscription.changed(collectionName, doc._id, doc)
-        } else {
-          this.publishedDocs.add(collectionName, doc._id)
-          await this._publishChildrenOf(doc)
-          this.subscription.added(collectionName, doc)
-        }
+          if (alreadyPublished) {
+            debugLog('Publication.observeHandle.added', `${collectionName}:${doc._id} already published`)
+            this.publishedDocs.unflagForRemoval(doc._id)
+            this._republishChildrenOf(doc)
+            this.subscription.changed(collectionName, doc._id, doc)
+          } else {
+            this.publishedDocs.add(collectionName, doc._id)
+            await this._publishChildrenOf(doc)
+            this.subscription.added(collectionName, doc)
+          }
+
+          // resolve the promise at the end of the added callback
+          resolve();
+        });
+
+        // store the promise
+        this.addedPromises.push(addedPromise);
       }),
       changed: Meteor.bindEnvironment((newDoc, oldDoc) => {
         debugLog('Publication.observeHandle.changed', `${collectionName}:${newDoc._id}`)

--- a/lib/publication.js
+++ b/lib/publication.js
@@ -19,7 +19,7 @@ class Publication {
     this.publishedDocs = new PublishedDocumentList()
     this.collectionName = options.collectionName
     // property to store promises for added callbacks
-    this.addedPromises = [];
+    this.addedPromises = []
   }
 
   async publish () {
@@ -48,11 +48,11 @@ class Publication {
           }
 
           // resolve the promise at the end of the added callback
-          resolve();
-        });
+          resolve()
+        })
 
         // store the promise
-        this.addedPromises.push(addedPromise);
+        this.addedPromises.push(addedPromise)
       }),
       changed: Meteor.bindEnvironment((newDoc, oldDoc) => {
         debugLog('Publication.observeHandle.changed', `${collectionName}:${newDoc._id}`)

--- a/lib/publication.js
+++ b/lib/publication.js
@@ -33,22 +33,11 @@ class Publication {
     // It's only needed when publish is being recursively run.
     this.observeHandle = this.cursor.observe({
       added: Meteor.bindEnvironment(async (doc) => {
-        const addedPromise = new Promise(async (resolve) => {
-          const alreadyPublished = this.publishedDocs.has(doc._id)
-
-          if (alreadyPublished) {
-            debugLog('Publication.observeHandle.added', `${collectionName}:${doc._id} already published`)
-            this.publishedDocs.unflagForRemoval(doc._id)
-            this._republishChildrenOf(doc)
-            this.subscription.changed(collectionName, doc._id, doc)
-          } else {
-            this.publishedDocs.add(collectionName, doc._id)
-            await this._publishChildrenOf(doc)
-            this.subscription.added(collectionName, doc)
-          }
-
-          // resolve the promise at the end of the added callback
-          resolve()
+        const addedPromise = new Promise((resolve, reject) => {
+          // call the async function to handle the 'added' logic
+          this._handleAddedAsync(doc, collectionName)
+            .then(resolve) // resolve the promise at the end of the 'added' callback
+            .catch(reject)
         })
 
         // store the promise
@@ -73,6 +62,21 @@ class Publication {
     debugLog('Publication.unpublish', this._getCollectionName())
     this._stopObservingCursor()
     this._unpublishAllDocuments()
+  }
+
+  async _handleAddedAsync(doc, collectionName) {
+    const alreadyPublished = this.publishedDocs.has(doc._id)
+
+    if (alreadyPublished) {
+      debugLog('Publication.observeHandle.added', `${collectionName}:${doc._id} already published`)
+      this.publishedDocs.unflagForRemoval(doc._id)
+      this._republishChildrenOf(doc)
+      this.subscription.changed(collectionName, doc._id, doc)
+    } else {
+      this.publishedDocs.add(collectionName, doc._id)
+      await this._publishChildrenOf(doc)
+      this.subscription.added(collectionName, doc)
+    }
   }
 
   async _republish () {

--- a/lib/publication.js
+++ b/lib/publication.js
@@ -64,7 +64,7 @@ class Publication {
     this._unpublishAllDocuments()
   }
 
-  async _handleAddedAsync(doc, collectionName) {
+  async _handleAddedAsync (doc, collectionName) {
     const alreadyPublished = this.publishedDocs.has(doc._id)
 
     if (alreadyPublished) {

--- a/lib/publish_composite.js
+++ b/lib/publish_composite.js
@@ -20,6 +20,9 @@ function publishComposite (name, options) {
       publications.forEach(pub => pub.unpublish())
     })
 
+    // wait for all publications to finish processing initial added callbacks
+    await Promise.all(publications.flatMap(pub => pub.addedPromises));
+
     debugLog('Meteor.publish', 'ready')
     this.ready()
   })

--- a/lib/publish_composite.js
+++ b/lib/publish_composite.js
@@ -21,7 +21,7 @@ function publishComposite (name, options) {
     })
 
     // wait for all publications to finish processing initial added callbacks
-    await Promise.all(publications.flatMap(pub => pub.addedPromises));
+    await Promise.all(publications.flatMap(pub => pub.addedPromises))
 
     debugLog('Meteor.publish', 'ready')
     this.ready()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-composite",
-  "version": "1.8.5-beta.1",
+  "version": "1.8.5-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-composite",
-  "version": "1.8.4",
+  "version": "1.8.5-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 Package.describe({
   name: 'reywood:publish-composite',
   summary: 'Publish a set of related documents from multiple collections with a reactive join.',
-  version: '1.8.4',
+  version: '1.8.5-beta.1',
   git: 'https://github.com/Meteor-Community-Packages/meteor-publish-composite'
 })
 
@@ -11,7 +11,7 @@ Npm.depends({
 })
 
 Package.onUse((api) => {
-  api.versionsFrom(['1.8.3', '2.8.1', '3.0-alpha.15'])
+  api.versionsFrom(['1.8.3', '2.8.1', '3.0-alpha.19'])
   api.use([
     'check',
     'ecmascript',

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@
 Package.describe({
   name: 'reywood:publish-composite',
   summary: 'Publish a set of related documents from multiple collections with a reactive join.',
-  version: '1.8.5-beta.1',
+  version: '1.8.5-beta.2',
   git: 'https://github.com/Meteor-Community-Packages/meteor-publish-composite'
 })
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-composite",
-  "version": "1.8.5-beta.1",
+  "version": "1.8.5-beta.2",
   "private": true,
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-composite",
-  "version": "1.8.4",
+  "version": "1.8.5-beta.1",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #163

In the main publication, `this.ready()` is being fired too early. To fix that, we track when all initial documents have been processed by the `added` callback in `this.observeHandle`, for all children. We use a Promise for each child and resolve it after the callback body has run. Then, `this.ready()` executes after all these promises have resolved, 
