### PR TITLE
Fix for conflicting cursor events

### DIFF
--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -22,7 +22,8 @@ class Subscription {
   added (collectionName, doc) {
     this.refCounter.increment(collectionName, doc._id)
 
-    if (this._hasDocChanged(collectionName, doc._id, doc)) {
+    const existingDoc = this.docHash[buildHashKey(collectionName, doc.id)]
+    if (!existingDoc) {
       debugLog('Subscription.added', `${collectionName}:${doc._id}`)
       this.meteorSub.added(collectionName, doc._id, doc)
       this._addDocHash(collectionName, doc)


### PR DESCRIPTION
An attempt to fix conflicting cursor events in related to this [grapher issue](https://github.com/cult-of-coders/grapher/issues/481). Might break other things :shrug:

This happens when the same document exists in the children of more than one parent cursor.

What happens:
1. `added` gets triggered from one parent
  1.1 `docHash` is updated with the new document
2. `changed` gets triggered from the other parent
  2.1 `_shouldSendChanges` is false because the same document already exists in `docHash`
  2.2 `this.meteorSub.changed` is not called
  
This is an issue because if `this.meteorSub.changed` is not called, the change is not sent through the DDP. 
  