### PR TITLE
fixed race condition waiting for documents to be added 

### DIFF
--- a/lib/publication.js
+++ b/lib/publication.js
@@ -18,8 +18,6 @@ class Publication {
     this.childrenOptions = options.children || []
     this.publishedDocs = new PublishedDocumentList()
     this.collectionName = options.collectionName
-    // property to store promises for added callbacks
-    this.addedPromises = []
   }
 
   async publish () {
@@ -27,6 +25,7 @@ class Publication {
     if (!this.cursor) { return }
 
     const collectionName = this._getCollectionName()
+    const promises = []
 
     // Use Meteor.bindEnvironment to make sure the callbacks are run with the same
     // environmentVariables as when publishing the "parent".
@@ -41,7 +40,7 @@ class Publication {
         })
 
         // store the promise
-        this.addedPromises.push(addedPromise)
+        promises.push(addedPromise)
       }),
       changed: Meteor.bindEnvironment((newDoc, oldDoc) => {
         debugLog('Publication.observeHandle.changed', `${collectionName}:${newDoc._id}`)
@@ -56,6 +55,8 @@ class Publication {
         this._removeDoc(collectionName, doc._id)
       }
     })
+    // await the promises
+    await Promise.all(promises)
   }
 
   unpublish () {

--- a/lib/publication.js
+++ b/lib/publication.js
@@ -18,6 +18,8 @@ class Publication {
     this.childrenOptions = options.children || []
     this.publishedDocs = new PublishedDocumentList()
     this.collectionName = options.collectionName
+    this.promises = []
+    this.childrenPublication = []
   }
 
   async publish () {
@@ -25,7 +27,6 @@ class Publication {
     if (!this.cursor) { return }
 
     const collectionName = this._getCollectionName()
-    const promises = []
 
     // Use Meteor.bindEnvironment to make sure the callbacks are run with the same
     // environmentVariables as when publishing the "parent".
@@ -40,7 +41,7 @@ class Publication {
         })
 
         // store the promise
-        promises.push(addedPromise)
+        this.promises.push(addedPromise)
       }),
       changed: Meteor.bindEnvironment((newDoc, oldDoc) => {
         debugLog('Publication.observeHandle.changed', `${collectionName}:${newDoc._id}`)
@@ -55,8 +56,6 @@ class Publication {
         this._removeDoc(collectionName, doc._id)
       }
     })
-    // await the promises
-    await Promise.all(promises)
   }
 
   unpublish () {
@@ -106,6 +105,7 @@ class Publication {
       : this.childrenOptions
     await Promise.all(children.map(async (options) => {
       const pub = new Publication(this.subscription, options, [doc].concat(this.args))
+      this.childrenPublication.push(pub)
       this.publishedDocs.addChildPub(doc._id, pub)
       await pub.publish()
     }))
@@ -169,6 +169,11 @@ class Publication {
     this.publishedDocs.eachChildPub(docId, (publication) => {
       publication.unpublish()
     })
+  }
+
+  async awaitPromises () {
+    await Promise.all(this.promises)
+    await Promise.all(this.childrenPublication.map(p => p.awaitPromises()))
   }
 }
 

--- a/lib/publish_composite.js
+++ b/lib/publish_composite.js
@@ -20,6 +20,7 @@ function publishComposite (name, options) {
       publications.forEach(pub => pub.unpublish())
     })
 
+    await Promise.all(publications.map(p => p.awaitPromises()))
     debugLog('Meteor.publish', 'ready')
     this.ready()
   })

--- a/lib/publish_composite.js
+++ b/lib/publish_composite.js
@@ -20,9 +20,6 @@ function publishComposite (name, options) {
       publications.forEach(pub => pub.unpublish())
     })
 
-    // wait for all publications to finish processing initial added callbacks
-    await Promise.all(publications.flatMap(pub => pub.addedPromises))
-
     debugLog('Meteor.publish', 'ready')
     this.ready()
   })


### PR DESCRIPTION
<!--
Thank you for your interest in the project! We appreciate your submission!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

Read a guide on [opening pull requests](https://opensource.guide/how-to-contribute/#opening-a-pull-request).

-->

<!-- What changes are being made? (What feature/bug is being fixed here?)
Check this [list](https://help.github.com/en/articles/closing-issues-using-keywords) of valid keywords.
-->
## What

Waiting for documents to get added results in a race condition. [this bug](https://github.com/Meteor-Community-Packages/meteor-publish-composite/issues/67)
## Why
I narrowed down to [this promise](https://github.com/Meteor-Community-Packages/meteor-publish-composite/blob/master/lib/publication.js#L44) and how it is awaited [here](https://github.com/Meteor-Community-Packages/meteor-publish-composite/blob/master/lib/publish_composite.js#L24). I have no idea why it results in a race condition, but it does please see [here](https://github.com/Meteor-Community-Packages/meteor-publish-composite/issues/67#issuecomment-1967523876). I suspect it has to do with the publication instantiation [here](https://github.com/Meteor-Community-Packages/meteor-publish-composite/blob/master/lib/publication.js#L107). The fix is to keep track of children publications and to await them recursively. It seems to fix the issue.
<!-- Anything else beside this PR that needs to happen? -->
