### PR TITLE
Revert "Fix for conflicting cursor events"

### DIFF
--- a/lib/subscription.js
+++ b/lib/subscription.js
@@ -23,8 +23,7 @@ class Subscription {
   added (collectionName, doc) {
     this.refCounter.increment(collectionName, doc._id)
 
-    const existingDoc = this.docHash[buildHashKey(collectionName, doc.id)]
-    if (!existingDoc) {
+    if (this._hasDocChanged(collectionName, doc._id, doc)) {
       debugLog('Subscription.added', `${collectionName}:${doc._id}`)
       this.meteorSub.added(collectionName, doc._id, doc)
       this._addDocHash(collectionName, doc)


### PR DESCRIPTION
Reverts Meteor-Community-Packages/meteor-publish-composite#177
The code only seems to work because `doc.id` is `undefined`. Thus `added` will be executed unnecessarily, likely adding a large performance penalty. Also, the original code change does not attempt to do anything new from what `_hasDocChanged` already does.

[UPDATE]
There is an ongoing conversation under https://github.com/Meteor-Community-Packages/meteor-publish-composite/pull/177.