### PR TITLE
Add await for children() option

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,9 @@ Arguments
       async children(parentNotification) {
         // children is a function (can be asynchronous) that returns an array of objects.
         // It takes parent documents as arguments and dynamically builds children array.
-        const userAllowsNotifications = await CustomUserLibrary.allowsNotifications(); // async children function allows the use of await to dynamically build children array
+
+        // async children function allows the use of await to dynamically build children array
+        const userAllowsNotifications = await CustomUserLibrary.allowsNotifications(); 
 
         if (!userAllowsNotifications) {
           return [];

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Arguments
 
     The name of the publication
 
-* **`options`** -- *object literal or callback function*
+* **`options`** -- *object literal or callback function (supports async)*
 
     An object literal specifying the configuration of the composite publication **or** a function that returns said object literal. If a function is used, it will receive the arguments passed to `Meteor.subscribe('myPub', arg1, arg2, ...)` (much like the `func` argument of [`Meteor.publish`](http://docs.meteor.com/#meteor_publish)). Basically, if your publication will take **no** arguments, pass an object literal for this argument. If your publication **will** take arguments, use a function that returns an object literal.
 
@@ -45,7 +45,7 @@ Arguments
 
         A function that returns a MongoDB cursor (e.g., `return Meteor.users.find({ active: true });`)
 
-    * **`children`** -- *array (optional)* or *function*
+    * **`children`** -- *array (optional)* or *function (supports async)*
 
         - An array containing any number of object literals with this same structure
         - A function with top level documents as arguments. It helps dynamically build
@@ -103,9 +103,15 @@ Arguments
       find() {
           return Notifications.find();
       },
-      children(parentNotification) {
-        // children is a function that returns an array of objects.
+      async children(parentNotification) {
+        // children is a function (can be asynchronous) that returns an array of objects.
         // It takes parent documents as arguments and dynamically builds children array.
+        const userAllowsNotifications = await CustomUserLibrary.allowsNotifications(); // async children function allows the use of await to dynamically build children array
+
+        if (!userAllowsNotifications) {
+          return [];
+        }
+    
         if (parentNotification.type === 'about_post') {
           return [{
             find(notification) {
@@ -254,6 +260,7 @@ publishComposite('postsByUser', async function(userId) {
         },
         children: [
             // This section will be similar to that of the previous example.
+            // Note from above, children can be a function (optionally async) in order to dynamically build the children array
         ]
     }
 });

--- a/lib/publication.js
+++ b/lib/publication.js
@@ -101,7 +101,7 @@ class Publication {
 
   async _publishChildrenOf (doc) {
     const children = typeof this.childrenOptions === 'function'
-      ? this.childrenOptions(doc, ...this.args)
+      ? await this.childrenOptions(doc, ...this.args)
       : this.childrenOptions
     await Promise.all(children.map(async (options) => {
       const pub = new Publication(this.subscription, options, [doc].concat(this.args))


### PR DESCRIPTION
<!--
Thank you for your interest in the project! We appreciate your submission!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!

Read a guide on [opening pull requests](https://opensource.guide/how-to-contribute/#opening-a-pull-request).

-->

<!-- What changes are being made? (What feature/bug is being fixed here?)
Check this [list](https://help.github.com/en/articles/closing-issues-using-keywords) of valid keywords.
-->
## What
Adds an await to the `_publishChildrenOf` function where `this.childrenOptions()` is called. If this.childrenOptions is already synchronous, this change has no effect but allows people to define children() option as async so that they can call asynchronous code before returning. 
<!-- Why are these changes necessary? -->
## Why
Our company is in the process of migrating to meteor 3, so we've had to do a lot of refactoring of our server-side code, a lot of which is used in our publication code. I've found that the object literal that needs to be returned from the publish-composite definition allows an async function that resolves to an object literal with the find(), and (optionally a function) children(). This has helped a lot in this process, however, we had some calls to async functions inside some of the objects referenced in the children() section of the publish definition. 

Looking through the source I found that the function that processes the publication already was asynchronous, but if the children option was a function, it was not awaiting. This seems intentional but simply adding an await before that function call would allow people to use asynchronous calls inside their children() function. The code change is very minimal and was able to run the tests which all passed. 
<!-- Anything else beside this PR that needs to happen? -->

## Testing
![image](https://github.com/user-attachments/assets/20d2a7f3-5a98-4a31-87d4-0680c42fbf6a)

